### PR TITLE
RAM limit increased

### DIFF
--- a/.codenvy.json
+++ b/.codenvy.json
@@ -7,7 +7,7 @@
         "machines": {
           "dev-machine": {
             "attributes": {
-              "memoryLimitBytes": "1073741824"
+              "memoryLimitBytes": "2147483648"
             },
             "servers": {},
             "agents": [


### PR DESCRIPTION
Current limit caused in 'Out of memory' error by starting wildfly server (see #1). [Referred to Codenvy](https://blog.codenvy.com/3-9-release-pay-as-you-go-pricing-52e86cbcf1ab), there is a RAM allocation up to four gigabytes possible (in the free version).